### PR TITLE
Fix unexpected EOF error

### DIFF
--- a/charts/nginx-ingress-controller/templates/loadbalancer.yaml
+++ b/charts/nginx-ingress-controller/templates/loadbalancer.yaml
@@ -10,10 +10,11 @@ metadata:
   {{- if .Values.k8sJenkinsMgmt.loadbalancer.annotations.enabled}}
   annotations:
   {{- if .Values.k8sJenkinsMgmt.loadbalancer.annotations.external_dns_hostname }}
-    external-dns.alpha.kubernetes.io/hostname: {{ .Values.k8sJenkinsMgmt.loadbalancer.annotations.external_dns_hostname }}}}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.k8sJenkinsMgmt.loadbalancer.annotations.external_dns_hostname }}
   {{- end }}
   {{- if .Values.k8sJenkinsMgmt.loadbalancer.annotations.external_dns_ttl }}
-    external-dns.alpha.kubernetes.io/ttl: {{ .Values.k8sJenkinsMgmt.loadbalancer.annotations.external_dns_ttl }}}}
+    external-dns.alpha.kubernetes.io/ttl: {{ .Values.k8sJenkinsMgmt.loadbalancer.annotations.external_dns_ttl }}
+  {{- end }}
   {{- end }}
 
 spec:


### PR DESCRIPTION
This will fix the EOF error during a Helm chart installation.

```
Error: parse error at (nginx-ingress-controller/templates/loadbalancer.yaml:35): unexpected EOF
```