### PR TITLE
Fix unable to decode error when loadbalancer annotations are enabled

### DIFF
--- a/charts/nginx-ingress-controller/templates/loadbalancer.yaml
+++ b/charts/nginx-ingress-controller/templates/loadbalancer.yaml
@@ -10,13 +10,12 @@ metadata:
   {{- if .Values.k8sJenkinsMgmt.loadbalancer.annotations.enabled}}
   annotations:
   {{- if .Values.k8sJenkinsMgmt.loadbalancer.annotations.external_dns_hostname }}
-    external-dns.alpha.kubernetes.io/hostname: {{ .Values.k8sJenkinsMgmt.loadbalancer.annotations.external_dns_hostname }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.k8sJenkinsMgmt.loadbalancer.annotations.external_dns_hostname | quote }}
   {{- end }}
   {{- if .Values.k8sJenkinsMgmt.loadbalancer.annotations.external_dns_ttl }}
-    external-dns.alpha.kubernetes.io/ttl: {{ .Values.k8sJenkinsMgmt.loadbalancer.annotations.external_dns_ttl }}
+    external-dns.alpha.kubernetes.io/ttl: {{ .Values.k8sJenkinsMgmt.loadbalancer.annotations.external_dns_ttl | quote }}
   {{- end }}
   {{- end }}
-
 spec:
   # externalTrafficPolicy: Local
   type: LoadBalancer


### PR DESCRIPTION
This will fix an error that occurs when you try to install the `nginx-ingress-controller` and the load balancer annotations are enabled.

Here is the error message:
```txt
Error: unable to build kubernetes objects from release manifest: unable to decode "": resource.metadataOnlyObject.ObjectMeta: v1.ObjectMeta.Annotations: ReadString: expects " or n, but found 3, error found in #10 byte of ...|.io/ttl":300},"label|..., bigger context ...|ogix.net","external-dns.alpha.kubernetes.io/ttl":300},"labels":{"app.kubernetes.io/name":"ingress-ng|...
helm.go:94: [debug] unable to decode "": resource.metadataOnlyObject.ObjectMeta: v1.ObjectMeta.Annotations: ReadString: expects " or n, but found 3, error found in #10 byte of ...|.io/ttl":300},"label|..., bigger context ...|ogix.net","external-dns.alpha.kubernetes.io/ttl":300},"labels":{"app.kubernetes.io/name":"ingress-ng|...
unable to build kubernetes objects from release manifest
```